### PR TITLE
Parallel insert into MySql

### DIFF
--- a/db/schema.sql
+++ b/db/schema.sql
@@ -16,7 +16,7 @@ CREATE TABLE `accounts` (
   `block_count` int(11) DEFAULT NULL,
   `confirmation_height` int(11) DEFAULT NULL,
   `confirmation_height_frontier` char(64) DEFAULT NULL,
-  `representative` char(65) NOT NULL,
+  `representative` char(65)  NULL,
   `weight` varchar(39) DEFAULT NULL,
   `pending` varchar(39) DEFAULT NULL,
   `key` char(64) DEFAULT NULL,
@@ -25,7 +25,7 @@ CREATE TABLE `accounts` (
   INDEX `representative` (`representative`),
   INDEX `pending` (`pending`),
   INDEX `modified_timestamp` (`modified_timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=FIXED;
 
 -- --------------------------------------------------------
 
@@ -59,7 +59,7 @@ CREATE TABLE `blocks` (
   INDEX `balance` (`balance`),
   INDEX `representative` (`representative`),
   INDEX `local_timestamp` (`local_timestamp`)
-) ENGINE=MyISAM DEFAULT CHARSET=utf8 ROW_FORMAT=FIXED;
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=FIXED;
 
 -- --------------------------------------------------------
 

--- a/scripts/export-lmdb-to-mysql.py
+++ b/scripts/export-lmdb-to-mysql.py
@@ -104,7 +104,7 @@ args = parser.parse_args()
 mysql_config = config["mysql"]["connection"]
 
 
-def processInput(data_accounts):
+def processAccounts(data_in):
     export_counter = 0
     conn = mysql.connector.connect(
             user=mysql_config["user"],
@@ -113,14 +113,34 @@ def processInput(data_accounts):
             database=mysql_config["database"],
         )
     conn.autocommit = False
-    mysql_cursor = conn.cursor()    
-    for data_account in data_accounts:   
+    mysql_cursor = conn.cursor()  
+    mysql_cursor.execute("SET foreign_key_checks = 0")
+    mysql_cursor.execute("SET unique_checks = 0")  
+    for data_account in data_in:   
         mysql_cursor.execute(add_account, data_account) 
         export_counter += 1
-        print("import_count : [{}]".format(export_counter))
+        #print("import_count : [{}]".format(export_counter))
     conn.commit()        
     conn.close()
-    
+
+def processBlocks(data_in):
+    export_counter = 0
+    conn = mysql.connector.connect(
+            user=mysql_config["user"],
+            host=mysql_config["host"],
+            password=mysql_config["password"],
+            database=mysql_config["database"],
+        )
+    conn.autocommit = False
+    mysql_cursor = conn.cursor() 
+    mysql_cursor.execute("SET foreign_key_checks = 0")
+    mysql_cursor.execute("SET unique_checks = 0")   
+    for data_blocks in data_in:   
+        mysql_cursor.execute(add_block, data_blocks) 
+        export_counter += 1
+        #print("import_count : [{}]".format(export_counter))
+    conn.commit()        
+    conn.close()  
 
 try:
     # Override database filename
@@ -130,15 +150,16 @@ try:
     if not os.path.isfile(filename):
         raise Exception("Database doesn't exist")
 
-    env = lmdb.open(filename, subdir=False, max_dbs=100)   
+    env = lmdb.open(filename, subdir=False, max_dbs=100) 
+    num_cores = multiprocessing.cpu_count()     
 
     # Accounts table
     if args.table == "all" or args.table == "accounts":
         print("Importing Accounts")
         accounts_db = env.open_db("accounts".encode())
         confirmation_db = env.open_db("confirmation_height".encode())
-        memory_accounts = []
-        num_cores = multiprocessing.cpu_count() 
+        mem_cache = []
+        
 
         count = 0
         with env.begin() as txn:
@@ -201,22 +222,31 @@ try:
                 )
                 
                 tmp.append(data_account) 
-                # memory_accounts.append(data_account)
-
                 count += 1                                               
                 
-                if count >= 500000: #args.count:
-                    memory_accounts.append(tmp)
+                # if count >= args.count:
+                #     mem_cache.append(tmp)
+                #     break
+                # if count % 25000 == 0:                 
+                #     mem_cache.append(tmp)
+                #     tmp = []
+                if count >= args.count:
+                    #add the last batch of accounts to mysql
+                    mem_cache.append(tmp)
+                    Parallel(n_jobs=num_cores)(delayed(processBlocks)(data_accounts) for data_accounts in mem_cache)
                     break
-                if count % 25000 == 0:                 
-                    memory_accounts.append(tmp)
+                if count % 500 == 0:                 
+                    mem_cache.append(tmp)
                     tmp = []
+                if count % 10000 == 0:
+                    Parallel(n_jobs=num_cores)(delayed(processBlocks)(data_accounts) for data_accounts in mem_cache)
+                    mem_cache2 = []
             
             cursor.close()
         if count == 0:
             print("(empty)\n")
         
-        Parallel(n_jobs=num_cores)(delayed(processInput)(data_accounts) for data_accounts in memory_accounts)      
+        Parallel(n_jobs=num_cores)(delayed(processAccounts)(data_accounts) for data_accounts in mem_cache)      
             
            
             
@@ -224,21 +254,14 @@ try:
 
     # blocks table
     if args.table == "all" or args.table == "blocks":
-    
-        mysql_config = config["mysql"]["connection"]
-        cnx = mysql.connector.connect(
-            user=mysql_config["user"],
-            host=mysql_config["host"],
-            password=mysql_config["password"],
-            database=mysql_config["database"],
-        )
-        mysql_cursor = cnx.cursor()    
-         
+           
+        mem_cache2 = [] 
         print("Importing State Blocks")
         blocks_db = env.open_db("blocks".encode())
         confirmation_db = env.open_db("confirmation_height".encode())
 
         with env.begin() as txn:
+            tmp = []
             cursor = txn.cursor(blocks_db)
             if args.key:
                 cursor.set_key(bytearray.fromhex(args.key))
@@ -396,15 +419,23 @@ try:
                     data_block["amount"] = balance
 
                 data_block["confirmed"] = "1" if height >= data_block["height"] else "0"
-
-                mysql_cursor.execute(add_block, data_block)
+                                
+                tmp.append(data_block) 
+                count += 1                                               
                 
-
-                count += 1
                 if count >= args.count:
+                    mem_cache2.append(tmp)
+                    Parallel(n_jobs=num_cores)(delayed(processBlocks)(data_blocks) for data_blocks in mem_cache2)
                     break
-            cnx.commit()
-            mysql_cursor.close()
+                if count % 1000 == 0:                 
+                    mem_cache2.append(tmp)
+                    tmp = []
+                if count % 20000 == 0:
+                    Parallel(n_jobs=num_cores)(delayed(processBlocks)(data_blocks) for data_blocks in mem_cache2)
+                    mem_cache2 = []
+               
+                    
+                       
             cursor.close()
         if count == 0:
             print("(empty)\n")

--- a/scripts/export-lmdb-to-mysql.py
+++ b/scripts/export-lmdb-to-mysql.py
@@ -200,22 +200,23 @@ try:
                     height_info.frontier.hex().upper(),
                 )
                 
-                # tmp.append(data_account) 
-                memory_accounts.append(data_account)
+                tmp.append(data_account) 
+                # memory_accounts.append(data_account)
 
                 count += 1                                               
                 
-                if count >= 1000000: #args.count: 
+                if count >= 500000: #args.count:
+                    memory_accounts.append(tmp)
                     break
-                # if count % 10000 == 0:                 
-                    # memory_accounts.append(tmp)
-                    # tmp = []
+                if count % 25000 == 0:                 
+                    memory_accounts.append(tmp)
+                    tmp = []
             
             cursor.close()
         if count == 0:
             print("(empty)\n")
         
-        # Parallel(n_jobs=num_cores)(delayed(processInput)(data_accounts) for data_accounts in memory_accounts)      
+        Parallel(n_jobs=num_cores)(delayed(processInput)(data_accounts) for data_accounts in memory_accounts)      
             
            
             


### PR DESCRIPTION
Please feel free to see if this improves the performance.

- Change MySql Engine from MyISAM to InnoDB to allow inserts with autocommit disabled
- Commit only after 500k rows instead of 1 row
- Add parallelism (500k rows are chunked into 10k rows per transactions)
- some minor fixes : Uncomment account inserts, modify schema

Remaining bottleneck : Reading from lmdb
